### PR TITLE
Duration between lines not per stream and a single end token printed

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -529,7 +529,7 @@ mod tests {
         printer.print(&Token::LineFeed).unwrap();
         printer.print(&Token::Char('B')).unwrap();
 
-        //assert_all_timestamps_used(&printer);
+        assert_all_timestamps_used(&printer);
         assert_printed!(
             stream,
             "00:03.000             prefix: A\n",

--- a/src/output/timestamp.rs
+++ b/src/output/timestamp.rs
@@ -4,7 +4,6 @@ use std::time::Duration;
 #[cfg(not(test))]
 use std::time::SystemTime;
 
-#[derive(Clone)]
 pub struct Timestamp {
     #[cfg(not(test))]
     start_time: SystemTime,
@@ -47,7 +46,7 @@ impl Timestamp {
             .expect("Unexpected request for timestamp")
     }
 
-    pub fn expect_empty(&self) {
+    pub fn assert_all_used(&self) {
         assert!(
             self.expected_stamps.is_empty(),
             "All expected timestamps where not requested: {:?}",
@@ -82,6 +81,6 @@ mod tests {
     fn not_getting_all_timestamps_panics_when_checked() {
         let mut t = Timestamp::new();
         t.expect_get(Duration::from_millis(1234));
-        t.expect_empty();
+        t.assert_all_used();
     }
 }

--- a/tests/assertions/mod.rs
+++ b/tests/assertions/mod.rs
@@ -1,0 +1,72 @@
+/// Macro that wraps a future returning a result in a timeout and asserts that the future is
+/// succesful and does not timeout
+macro_rules! assert_ok {
+    ( $future:expr ) => {
+        match timeout(Duration::from_secs(3), $future).await {
+            Ok(timeout_result) => match timeout_result {
+                Ok(result) => result,
+                Err(error) => {
+                    panic!(
+                        "Operation '{}' should be successful but it failed with: {}",
+                        stringify!($future),
+                        error
+                    );
+                }
+            },
+            Err(_) => {
+                panic!(
+                    "Operation '{}' should be successful but it timeout out",
+                    stringify!($future),
+                );
+            }
+        }
+    };
+}
+pub(crate) use assert_ok;
+
+/// Macro that wraps a future in a timeout and asserts that the future likely would block
+/// indefinetely, by testing it with a short timeout
+macro_rules! assert_timeout {
+    ( $future:expr ) => {
+        match timeout(Duration::from_millis(500), $future).await {
+            Ok(timeout_result) => panic!(
+                "Operation '{}' should block but returned with: {:?}",
+                stringify!($future),
+                timeout_result
+            ),
+            Err(_) => {
+                // This is what we expect!
+            }
+        }
+    };
+}
+pub(crate) use assert_timeout;
+
+/// Expect program to print that end is reached of stdin
+macro_rules! assert_input_end {
+    ( $put:expr ) => {
+        assert_ok!($put.read_stdout_timestamp());
+        assert_ok!($put.read_stdout(": ␄\n"));
+    };
+}
+pub(crate) use assert_input_end;
+
+/// Expect program to print that end is reached of both stdout and stderr of the command executed
+/// by the program
+macro_rules! assert_command_output_end {
+    ( $put:expr ) => {
+        assert_ok!($put.read_stdout_timestamp());
+        assert_ok!($put.read_stdout(" stdout: ␄\n"));
+        assert_ok!($put.read_stderr_timestamp());
+        assert_ok!($put.read_stderr(" stderr: ␄\n"));
+    };
+}
+pub(crate) use assert_command_output_end;
+
+macro_rules! assert_near {
+    ( $expected:expr, $actual:expr, $delta:expr ) => {
+        assert!($expected + $delta >= $actual);
+        assert!($expected <= $actual + $delta);
+    };
+}
+pub(crate) use assert_near;

--- a/tests/assertions/mod.rs
+++ b/tests/assertions/mod.rs
@@ -46,7 +46,7 @@ pub(crate) use assert_timeout;
 macro_rules! assert_input_end {
     ( $put:expr ) => {
         assert_ok!($put.read_stdout_timestamp());
-        assert_ok!($put.read_stdout(": ␄\n"));
+        assert_ok!($put.read_stdout(": ␃\n"));
     };
 }
 pub(crate) use assert_input_end;
@@ -56,9 +56,7 @@ pub(crate) use assert_input_end;
 macro_rules! assert_command_output_end {
     ( $put:expr ) => {
         assert_ok!($put.read_stdout_timestamp());
-        assert_ok!($put.read_stdout(" stdout: ␄\n"));
-        assert_ok!($put.read_stderr_timestamp());
-        assert_ok!($put.read_stderr(" stderr: ␄\n"));
+        assert_ok!($put.read_stdout(" ------: ␃\n"));
     };
 }
 pub(crate) use assert_command_output_end;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -100,7 +100,7 @@ async fn delta_times_can_be_shown_after_timestamp() {
     put.close_stdin();
     let t3 = assert_ok!(put.read_stdout_timestamp());
     let d3 = assert_ok!(put.read_stdout_delta());
-    assert_ok!(put.read_stdout(": ␄\n"));
+    assert_ok!(put.read_stdout(": ␃\n"));
     assert!(t3 >= t2);
     assert_near!(t3 - t2, d3, Duration::from_millis(1));
 
@@ -135,10 +135,7 @@ async fn delta_times_are_common_for_stderr_and_stdout() {
     control.exit(0).await;
     assert_ok!(put.read_stdout_timestamp());
     assert_ok!(put.read_stdout_delta());
-    assert_ok!(put.read_stdout(" stdout: ␄\n"));
-    assert_ok!(put.read_stderr_timestamp());
-    assert_ok!(put.read_stderr_delta());
-    assert_ok!(put.read_stderr(" stderr: ␄\n"));
+    assert_ok!(put.read_stdout(" ------: ␃\n"));
 
     assert!(put.wait().await.success());
 }

--- a/tests/marionette_control/mod.rs
+++ b/tests/marionette_control/mod.rs
@@ -59,7 +59,7 @@ impl Drop for Bar {
 impl Bar {
     /// Creates a new control bar and waits for the marionette to open its HTTP server
     pub async fn new() -> Self {
-        let result = Self {
+        let mut result = Self {
             http_client: Some(reqwest::Client::new()),
             url: format!("http://localhost:{}", port()),
         };
@@ -67,8 +67,8 @@ impl Bar {
         result
     }
 
-    async fn wait_for_marionette(&self) {
-        for _ in 0..1000 {
+    async fn wait_for_marionette(&mut self) {
+        for _ in 0..10 {
             if self
                 .http_client
                 .as_ref()
@@ -80,8 +80,9 @@ impl Bar {
             {
                 return;
             }
-            tokio::time::sleep(Duration::from_millis(10)).await;
+            tokio::time::sleep(Duration::from_millis(100)).await;
         }
+        self.http_client = None;
         panic!("Marionette HTTP server doesn't seem to be started!");
     }
 

--- a/tests/program_under_test/mod.rs
+++ b/tests/program_under_test/mod.rs
@@ -98,6 +98,11 @@ impl Linetime {
         Self::read_delta(&mut self.stdout, &self.delta_regex, "stdout").await
     }
 
+    /// Reads a delta time from the program's stderr and returns it as a Duration
+    pub async fn read_stderr_delta(&mut self) -> Result<Duration, std::io::Error> {
+        Self::read_delta(&mut self.stderr, &self.delta_regex, "stderr").await
+    }
+
     /// Reads some text from the program's stdout and checks that it matches the expected text,
     /// otherwise it returns an error
     pub async fn read_stdout(&mut self, expected_text: &str) -> Result<(), std::io::Error> {


### PR DESCRIPTION
Duration should be from previously started line, regardless if from stderr or stdout of executed command.